### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   package-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ankhorage/react-native-reanimated-dnd-web/security/code-scanning/3](https://github.com/ankhorage/react-native-reanimated-dnd-web/security/code-scanning/3)

In general, fix this by explicitly defining a `permissions` block that grants only the minimal required scopes for the `GITHUB_TOKEN`. Since this workflow only checks out code and runs local builds/tests, it likely needs only read access to repository contents, and no write scopes.

The best minimal change without altering existing functionality is to add a top-level `permissions:` block after the `on:` section, applying to all jobs. For this workflow, `contents: read` is sufficient as a conservative baseline. This will ensure that `GITHUB_TOKEN` is restricted even if the repository or organization defaults are broader, and it will resolve the CodeQL warning for `consumer-matrix` and the other jobs.

Concretely, in `.github/workflows/ci.yml`, after line 8 (`workflow_dispatch:`) and before the `jobs:` key on line 10, insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
