### PR TITLE
fix(ci): run knip in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Knip
+        run: bun run knip
+
       - name: Release checks
         run: bun run release:check
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,6 +1,11 @@
 import { createKnipConfig } from '@ankhorage/devtools/knip';
 
 export default createKnipConfig({
-  ignoreDependencies: [],
+  entry: ['examples/src/main.tsx'],
+  ignoreDependencies: [
+    'react-native',
+    'react-native-gesture-handler',
+    'react-native-reanimated',
+  ],
   ignoreFiles: ['.prettierrc.js', 'eslint.config.mjs'],
 });

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,6 +6,7 @@ export default createKnipConfig({
     'react-native',
     'react-native-gesture-handler',
     'react-native-reanimated',
+    'react-native-web',
   ],
   ignoreFiles: ['.prettierrc.js', 'eslint.config.mjs'],
 });


### PR DESCRIPTION
## Summary

- add `bun run knip` to the package-check CI job
- configure Knip to treat the Vite example app entry as used
- ignore the intentionally referenced optional React Native peer dependencies

## Verification

Not run locally: repository checkout/network access is not available in this environment. The CI workflow now runs `bun run knip` before release checks.