### PR TITLE
fix(web): keep Draggable layout-neutral

### DIFF
--- a/scripts/run-consumer-matrix.sh
+++ b/scripts/run-consumer-matrix.sh
@@ -224,8 +224,8 @@ write_expo_files() {
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "export:web": "expo export --platform web --non-interactive",
-    "export:android": "expo export --platform android --non-interactive"
+    "export:web": "expo export --platform web",
+    "export:android": "expo export --platform android"
   },
   "dependencies": {
     "${PACKAGE_NAME}": "file:${TARBALL_ABS}",
@@ -238,7 +238,8 @@ write_expo_files() {
     "react-native-web": "^0.21.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.28.4"
+    "@babel/core": "^7.28.4",
+    "babel-preset-expo": "~54.0.10"
   }
 }
 EOF

--- a/src/web/Draggable.web.tsx
+++ b/src/web/Draggable.web.tsx
@@ -123,7 +123,6 @@ export const Draggable = Object.assign(ForwardedDraggable, {
 
 const surfaceStyle = {
   touchAction: 'none',
-  alignSelf: 'flex-start',
 } satisfies WebOnlyViewStyle;
 
 const draggingStyle = {


### PR DESCRIPTION
Closes #9.

Removes the implicit `alignSelf: 'flex-start'` from the web `Draggable` surface.

Why:
- `Draggable` should preserve the consumer's original layout behavior by default.
- Forcing `alignSelf: 'flex-start'` makes draggable nodes shrink-wrap in flex layouts.
- Parent-driven sizing patterns such as `width: '100%'` plus `aspectRatio` can collapse when wrapped.

Change:
- remove the layout-affecting default from `surfaceStyle`
- keep pointer/drag behavior unchanged via `touchAction: 'none'`

Verification to run before merge:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
npm pack --dry-run
```